### PR TITLE
Mark the package abandoned

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,5 +33,5 @@
     }
   },
   "minimum-stability": "stable",
-  "abandoned": true
+  "abandoned": "knplabs/knp-paginator-bundle"
 }

--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,6 @@
       "Facile\\PaginatorBundle\\": "src/"
     }
   },
-
-  "minimum-stability": "stable"
+  "minimum-stability": "stable",
+  "abandoned": true
 }


### PR DESCRIPTION
The last update is from 6 years ago. 

Looking at the [stats page on Packagist](https://packagist.org/packages/facile-it/paginator-bundle/stats) it's likely no one is currently using it.

What do you all think?